### PR TITLE
Improve typography and color contrast across the site

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -280,9 +280,9 @@ function copySSH() {
 
 .hero-tagline {
   font-family: 'Share Tech Mono', monospace;
-  font-size: clamp(0.7rem, 1.6vw, 0.9rem);
+  font-size: clamp(0.85rem, 1.8vw, 1rem);
   letter-spacing: 0.12em;
-  color: #555;
+  color: #888;
   text-transform: uppercase;
 }
 
@@ -322,10 +322,10 @@ function copySSH() {
   gap: 32px;
 }
 .nav-links a {
-  font-size: 0.72rem;
+  font-size: 0.8rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: #555;
+  color: #888;
   text-decoration: none;
   transition: color 0.15s;
 }
@@ -342,10 +342,10 @@ function copySSH() {
 }
 
 .connect-label {
-  font-size: 0.62rem;
+  font-size: 0.72rem;
   letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: #444;
+  color: #888;
   margin-bottom: 8px;
 }
 
@@ -375,7 +375,7 @@ function copySSH() {
 .copy-btn {
   background: transparent;
   border: none;
-  color: #3a3a3a;
+  color: #666;
   cursor: pointer;
   font-size: 0.9rem;
   padding: 2px 0;
@@ -386,9 +386,9 @@ function copySSH() {
 .copy-btn:hover, .copy-btn.copied { color: #dc3545; }
 
 .connect-hint {
-  font-size: 0.6rem;
+  font-size: 0.72rem;
   letter-spacing: 0.06em;
-  color: #333;
+  color: #777;
   margin-top: 7px;
 }
 
@@ -405,11 +405,11 @@ function copySSH() {
   align-items: center;
   gap: 8px;
   padding: 10px 22px;
-  border: 1px solid #222;
+  border: 1px solid #333;
   background: transparent;
-  color: #555;
+  color: #888;
   font-family: 'Share Tech Mono', monospace;
-  font-size: 0.8rem;
+  font-size: 0.875rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   border-radius: 4px;
@@ -421,14 +421,14 @@ function copySSH() {
 /* ── Attribution ─────────────────────────────────────────────────────── */
 
 .hero-org {
-  font-size: 0.62rem;
+  font-size: 0.72rem;
   letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: #2a2a2a;
+  color: #666;
 }
 
 .org-link {
-  color: #444;
+  color: #888;
   text-decoration: none;
   transition: color 0.15s;
 }
@@ -453,10 +453,10 @@ function copySSH() {
 .scroll-hint:hover { opacity: 1; }
 
 .scroll-hint-label {
-  font-size: 0.58rem;
+  font-size: 0.7rem;
   letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: #555;
+  color: #888;
 }
 
 .scroll-arrow {
@@ -472,8 +472,8 @@ function copySSH() {
 
 /* ── bracket decoration ───────────────────────────────────────────────── */
 
-.bracket::before { content: '[ '; color: #2a2a2a; transition: color 0.15s; }
-.bracket::after  { content: ' ]'; color: #2a2a2a; transition: color 0.15s; }
+.bracket::before { content: '[ '; color: #555; transition: color 0.15s; }
+.bracket::after  { content: ' ]'; color: #555; transition: color 0.15s; }
 .bracket:hover::before, .bracket:hover::after { color: #dc3545; }
 .bracket:hover { color: #dc3545; }
 
@@ -512,8 +512,8 @@ function copySSH() {
 }
 
 .section-body {
-  font-size: 0.95rem;
-  color: rgba(255,255,255,0.6);
+  font-size: 1rem;
+  color: rgba(255,255,255,0.75);
   line-height: 1.8;
   max-width: 58ch;
   margin-bottom: 16px;
@@ -540,10 +540,10 @@ function copySSH() {
 }
 
 .flag-label {
-  font-size: 0.6rem;
+  font-size: 0.7rem;
   letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: #555;
+  color: #888;
 }
 
 .flag-code {
@@ -572,7 +572,7 @@ function copySSH() {
 .step-num {
   font-family: 'HackTheFlag', monospace;
   font-size: clamp(2rem, 4vw, 3rem);
-  color: #2a2a2a;
+  color: #444;
   line-height: 1;
   min-width: 72px;
   flex-shrink: 0;
@@ -590,8 +590,8 @@ function copySSH() {
 }
 
 .step-body p {
-  font-size: 0.88rem;
-  color: rgba(255,255,255,0.5);
+  font-size: 0.95rem;
+  color: rgba(255,255,255,0.7);
   line-height: 1.7;
   max-width: 50ch;
   margin-bottom: 10px;
@@ -638,10 +638,10 @@ function copySSH() {
 }
 
 .footer-by {
-  font-size: 0.58rem;
+  font-size: 0.7rem;
   letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: #555;
+  color: #888;
 }
 
 .footer-social {
@@ -651,16 +651,16 @@ function copySSH() {
 }
 
 .footer-social a {
-  color: #555;
+  color: #888;
   text-decoration: none;
   transition: color 0.15s;
 }
 
 .footer-pgp {
-  font-size: 0.62rem;
+  font-size: 0.72rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: #333;
+  color: #777;
   text-decoration: none;
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -37,7 +37,7 @@ body {
 ::-webkit-scrollbar-thumb { background: #111; border-radius: 2px; }
 
 /* bracket decoration (non-React elements) */
-.bracket::before { content: '[ '; color: #333; transition: color 0.15s; }
-.bracket::after  { content: ' ]'; color: #333; transition: color 0.15s; }
+.bracket::before { content: '[ '; color: #666; transition: color 0.15s; }
+.bracket::after  { content: ' ]'; color: #666; transition: color 0.15s; }
 .bracket:hover::before, .bracket:hover::after { color: var(--red); }
 .bracket:hover { color: var(--red); }


### PR DESCRIPTION
## Summary
This PR enhances the visual hierarchy and readability of the site by systematically improving font sizes and color contrast throughout the design. The changes focus on making text more legible while maintaining the monospace aesthetic.

## Key Changes
- **Font Size Improvements**: Increased font sizes across multiple components for better readability
  - Hero tagline: `0.7rem` → `0.85rem` (min), `0.9rem` → `1rem` (max)
  - Navigation links: `0.72rem` → `0.8rem`
  - Connect label: `0.62rem` → `0.72rem`
  - Connect hint: `0.6rem` → `0.72rem`
  - Section body: `0.95rem` → `1rem`
  - Step body paragraphs: `0.88rem` → `0.95rem`
  - Footer text: `0.58rem` → `0.7rem`
  - Various other small text elements increased by 0.1-0.12rem

- **Color Contrast Enhancements**: Lightened dark text colors for improved contrast and readability
  - Primary text colors shifted from `#555` to `#888` across multiple components
  - Bracket decorations: `#2a2a2a`/`#333` → `#555`/`#666`
  - Step numbers: `#2a2a2a` → `#444`
  - Copy button: `#3a3a3a` → `#666`
  - Various secondary text colors adjusted to `#777`-`#888` range

- **Content Opacity Adjustments**: Increased opacity of white text on dark backgrounds
  - Section body: `rgba(255,255,255,0.6)` → `rgba(255,255,255,0.75)`
  - Step body paragraphs: `rgba(255,255,255,0.5)` → `rgba(255,255,255,0.7)`

- **Button Styling**: Slightly increased copy button font size (`0.8rem` → `0.875rem`) and adjusted border color (`#222` → `#333`)

## Implementation Details
All changes are CSS-only modifications to improve visual hierarchy and accessibility without altering any HTML structure or functionality. The adjustments maintain the monospace aesthetic while enhancing overall readability across the site.

https://claude.ai/code/session_012Khu8A8JvSjQxmQ4qX29Np